### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Hy on Monaxhyd
 ==============
 
 [![Build Status](https://travis-ci.org/algernon/monaxhyd.png?branch=master)](https://travis-ci.org/algernon/monaxhyd)
-[![Downloads](https://pypip.in/d/monaxhyd/badge.png)](https://crate.io/packages/monaxhyd)
-[![Version](https://pypip.in/v/monaxhyd/badge.png)](https://crate.io/packages/monaxhyd)
+[![Downloads](https://img.shields.io/pypi/dm/monaxhyd.svg)](https://crate.io/packages/monaxhyd)
+[![Version](https://img.shields.io/pypi/v/monaxhyd.svg)](https://crate.io/packages/monaxhyd)
 
 This library is a loose port of Clojure's [algo.monads][clj:monads] to
 [Hy][hylang]. It's a work heavily in progress at the moment, and it


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20monaxhyd))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `monaxhyd`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.