### PR TITLE
Drop Python <= 3.3 from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "pypy"
 install: pip install -r requirements.txt --allow-all-external


### PR DESCRIPTION
Hy no longer supports Python < 3.4
(see https://github.com/hylang/hy/pull/1646#issuecomment-400822377).