### PR TITLE
Use `defmacro/g!` and `require` a macro's dependencies within itself.

### DIFF
--- a/monaxhyd/core.hy
+++ b/monaxhyd/core.hy
@@ -14,27 +14,31 @@
 
 (require [hy.contrib.walk [let]])
 
-(defmacro monad [operations]
-  `(let [m-bind   'undefined
-         m-result 'undefined
-         m-zero   'undefined
-         m-plus   'undefined]
-        (let [~@operations]
-             {'m-result  m-result
-              'm-bind    m-bind
-              'm-zero    m-zero
-              'm-plus    m-plus})))
+(defmacro/g! monad [operations]
+  `(do
+     (require [hy.contrib.walk [let :as ~g!let]])
+     (~g!let [m-bind   'undefined
+              m-result 'undefined
+              m-zero   'undefined
+              m-plus   'undefined]
+      (~g!let [~@operations]
+               {'m-result  m-result
+                'm-bind    m-bind
+                'm-zero    m-zero
+                'm-plus    m-plus}))))
 
 (defmacro defmonad [name operations]
   `(setv ~name (monad ~operations)))
 
 (defmacro/g! with-monad [monad &rest exprs]
-  `(let [~g!g      ~monad
-         m-bind    (get ~g!g 'm-bind)
-         m-result  (get ~g!g 'm-result)
-         m-zero    (get ~g!g 'm-zero)
-         m-plus    (get ~g!g 'm-plus)]
-     ~@exprs))
+  `(do
+     (require [hy.contrib.walk [let :as ~g!let]])
+     (~g!let [~g!g      ~monad
+              m-bind    (get ~g!g 'm-bind)
+              m-result  (get ~g!g 'm-result)
+              m-zero    (get ~g!g 'm-zero)
+              m-plus    (get ~g!g 'm-plus)]
+      ~@exprs)))
 
 (defmacro domonad [name steps expr]
   (let [mexpr (t/.monad-expr steps expr)]

--- a/monaxhyd/monads.hy
+++ b/monaxhyd/monads.hy
@@ -10,7 +10,6 @@
 ;; from this software.
 
 (require [monaxhyd.core [*]])
-(require [hy.contrib.walk [let]])
 
 (defmonad identity-m
   [m-result (fn [r] r)


### PR DESCRIPTION
This should avoid accidental recapture and remove the need to manually `require` the `let` macro (see https://github.com/hylang/hy/issues/1650).

@algernon, what happened to the `develop` branch?